### PR TITLE
Fixed a memory leak

### DIFF
--- a/P4.cpp
+++ b/P4.cpp
@@ -297,5 +297,7 @@ int main() {
     assert(QHT4->member(24) == false);
     assert(QHT4->member(25) == false);
     
+    delete QHT4;
+    
     return 0;
 }


### PR DESCRIPTION
Whoever made the QHT4 pointer forgot to delete it at the end and that was a memory leak. I updated the code to delete the pointer.
